### PR TITLE
Add link to tutorial files in requirements

### DIFF
--- a/docs/modules/ROOT/pages/ecs-embedded.adoc
+++ b/docs/modules/ROOT/pages/ecs-embedded.adoc
@@ -21,6 +21,7 @@
 - https://git-scm.com/[Git]
 - JDK 1.8+
 - Apache Maven 3.2+
+- The tutorial files, available on https://github.com/hazelcast-guides/ecs-embedded[GitHub]
 
 == Create an Application
 


### PR DESCRIPTION
While following the tutorial I got quite confused at the mentions of `policy.json`, `role-policy.json` and `task-definition.json` because I had no idea where I was supposed to get those files.

This adds an entry to the tutorial requirements mentioning that some files are needed and linking to the tutorial's repo.